### PR TITLE
fix(#41): support more than one middleware stack

### DIFF
--- a/web/middleware/apmtracing/apmtracing.go
+++ b/web/middleware/apmtracing/apmtracing.go
@@ -27,6 +27,10 @@ func BuildApmMiddleware(ctx context.Context, options ApmMiddlewareOptions) func(
 		}
 	}
 
+	return GetApmMiddlewareAfterSetup(ctx, options)
+}
+
+func GetApmMiddlewareAfterSetup(_ context.Context, _ ApmMiddlewareOptions) func(http.Handler) http.Handler {
 	return apmchiv5.Middleware()
 }
 


### PR DESCRIPTION
- add support for a secondary web stack
- allows skipping one-time setup the second time